### PR TITLE
Fixes

### DIFF
--- a/reproducer/src/main/java/my/example/otel/reproducer/MainRoutes.java
+++ b/reproducer/src/main/java/my/example/otel/reproducer/MainRoutes.java
@@ -34,7 +34,7 @@ public class MainRoutes extends RouteBuilder {
                 // to simulate a parallel splitter
                 .setBody(e -> FAKE_XML_BODY)
                 .setHeader(Exchange.HTTP_METHOD, () -> "GET")
-                .split(super.body().tokenizeXML("order", "orders"))//.streaming().parallelProcessing()
+                .split(super.body().tokenizeXML("order", "orders")).synchronous(true)//.streaming().parallelProcessing()
                     .setBody(xpath("Parameter[@Name]", String.class))
                     .log(LOG_MESSAGE)
                     .to("direct:say-hi-rest-invoker")

--- a/reproducer/src/main/java/my/example/otel/reproducer/MainRoutes.java
+++ b/reproducer/src/main/java/my/example/otel/reproducer/MainRoutes.java
@@ -37,7 +37,7 @@ public class MainRoutes extends RouteBuilder {
                 .split(super.body().tokenizeXML("order", "orders")).synchronous(true)//.streaming().parallelProcessing()
                     .setBody(xpath("Parameter[@Name]", String.class))
                     .log(LOG_MESSAGE)
-                    .to("direct:say-hi-rest-invoker")
+                    .to("direct:say-hi-rest-invoker?synchronous=true")
                 .end()
 
                 .to("direct:pizza-soap-invoker")

--- a/reproducer/src/main/java/my/example/otel/reproducer/OpenTelemetryReproducer.java
+++ b/reproducer/src/main/java/my/example/otel/reproducer/OpenTelemetryReproducer.java
@@ -1,8 +1,10 @@
 package my.example.otel.reproducer;
 
+import org.apache.camel.opentelemetry.starter.CamelOpenTelemetry;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@CamelOpenTelemetry
 @SpringBootApplication
 public class OpenTelemetryReproducer {
 

--- a/reproducer/src/main/java/my/example/otel/reproducer/support/CxfBeans.java
+++ b/reproducer/src/main/java/my/example/otel/reproducer/support/CxfBeans.java
@@ -1,7 +1,12 @@
 package my.example.otel.reproducer.support;
 
 import https.www_w3schools_com.xml.TempConvertSoap;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import jakarta.annotation.PostConstruct;
 import org.apache.camel.component.cxf.common.DataFormat;
 import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
 import org.apache.camel.component.cxf.spring.jaxrs.SpringJAXRSClientFactoryBean;
@@ -19,6 +24,13 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 class CxfBeans {
+
+    @PostConstruct
+    void w3c() {
+        OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder()
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance())).build();
+        GlobalOpenTelemetry.set(openTelemetry);
+    }
 
     @Bean
     @ConditionalOnProperty(prefix = "reproducer", name = "enable-cxf-otel-features", havingValue = "true")


### PR DESCRIPTION
Adds some small fixes. Using the -i option with curl we can see the return headers containing the traceparent whose values match the one we see in the logs application side. Subsequent request start a new trace. Thanks !